### PR TITLE
Update Websocket URL from OKCoin.com to OKEX.com

### DIFF
--- a/okcoin-api.js
+++ b/okcoin-api.js
@@ -1,5 +1,5 @@
 function OKCoin(domain, channels, apiKey, secretKey) {
-    this.wsUrl = 'wss://real.okcoin.' + domain + ':10440/websocket/okcoinapi'
+    this.wsUrl = 'wss://real.okex.' + domain + ':10440/websocket/okcoinapi'
     this.apiKey = apiKey
     this.secretKey = secretKey
     this.channels = channels


### PR DESCRIPTION
Old URL: wss://real.okcoin.com:10440/websocket/okcoinapi
New URL: wss://real.okex.com:10440/websocket/okcoinapi